### PR TITLE
feat: Adding new actions for CD pipelines

### DIFF
--- a/azure-function-start-staging-slot/action.yml
+++ b/azure-function-start-staging-slot/action.yml
@@ -1,0 +1,60 @@
+name: Start Azure Functions staging slot
+description: "Start execution of the Azure Function staging slot"
+
+inputs:
+  branch:
+    required: true
+    description: The branch to deploy
+    type: string
+  client_id:
+    required: true
+    description: Azure Client ID
+    type: string
+  subscription_id:
+    required: true
+    description: Azure Subscription ID
+    type: string
+  tenant_id:
+    required: true
+    description: Azure Tenant ID
+    type: string
+  resource_group:
+    required: true
+    description: The resource group of the function to deploy
+    type: string
+  app_name:
+    required: true
+    description: The name of the function to deploy
+    type: string
+  registry_image:
+    required: true
+    description: The name of the image from container registry to be used
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      with:
+        ref: ${{ inputs.branch}}
+
+    - name: Login via Azure CLI
+      uses: azure/login@89d153571fe9a34ed70fcf9f1d95ab8debea7a73
+      with:
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
+
+    - name: 'Azure CLI script: start staging slot'
+      uses: azure/CLI@b0e31ae20280d899279f14c36e877b4c6916e2d3
+      if: ${{ (inputs.target == inputs.environment && inputs.target == 'prod') }}
+      with:
+        inlineScript: az functionapp start --name ${{ inputs.app_name }} --resource-group ${{ inputs.resource_group }} --slot staging
+
+    - name: 'Run Azure Functions Container Action: staging slot'
+      uses: Azure/functions-container-action@0aec6197033a72d3ca813f1aebd9391f639c2a8f
+      if: ${{ (inputs.target == inputs.environment && inputs.target == 'prod') }}
+      with:
+        app-name: ${{ inputs.app_name }}
+        image: ${{ inputs.registry_image }}
+        slot-name: staging

--- a/azure-function-stop-staging-slot/action.yml
+++ b/azure-function-stop-staging-slot/action.yml
@@ -1,0 +1,53 @@
+name: Stop Azure Functions staging slot
+description: "Stop execution of the Azure Function staging slot"
+
+inputs:
+  branch:
+    required: true
+    description: The branch to deploy
+    type: string
+  client_id:
+    required: true
+    description: Azure Client ID
+    type: string
+  subscription_id:
+    required: true
+    description: Azure Subscription ID
+    type: string
+  tenant_id:
+    required: true
+    description: Azure Tenant ID
+    type: string
+  resource_group:
+    required: true
+    description: The resource group of the function to deploy
+    type: string
+  app_name:
+    required: true
+    description: The name of the function to deploy
+    type: string
+  registry_image:
+    required: true
+    description: The name of the image from container registry to be used
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      with:
+        ref: ${{ inputs.branch}}
+
+    - name: Login via Azure CLI
+      uses: azure/login@89d153571fe9a34ed70fcf9f1d95ab8debea7a73
+      with:
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
+
+    - name: 'Azure CLI script: end staging slot'
+      uses: azure/CLI@b0e31ae20280d899279f14c36e877b4c6916e2d3
+      if: ${{ (inputs.target == inputs.environment && inputs.target == 'prod') }}
+      with:
+        inlineScript: |
+          az functionapp stop --name ${{ inputs.app_name }} --resource-group ${{ inputs.resource_group }} --slot staging

--- a/azure-functions-deploy/README.md
+++ b/azure-functions-deploy/README.md
@@ -1,0 +1,3 @@
+# Azure Functions Deploy
+
+This action makes a deployment of an Azure functions using a docker image.

--- a/azure-functions-deploy/README.md
+++ b/azure-functions-deploy/README.md
@@ -1,3 +1,35 @@
 # Azure Functions Deploy
 
 This action makes a deployment of an Azure functions using a docker image.
+
+```
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      app_name:
+        required: true
+        type: string
+      registry_image:
+        required: true
+        type: string
+        
+  [...]
+        
+  deploy:
+    name: Deploy Azure Function
+    runs-on: ubuntu-22.04
+    uses: pagopa/github-actions-template/azure-function-deploy@v1
+    with:
+      branch: ${{ github.ref_name }}
+      client_id: ${{ secrets.CLIENT_ID }}
+      tenant_id: ${{ secrets.TENANT_ID }}
+      subscription_id: ${{ secrets.SUBSCRIPTION_ID }}
+      app_name: ${{ inputs.app_name }}
+      registry_image: ${{ inputs.registry_image }}
+```

--- a/azure-functions-deploy/action.yml
+++ b/azure-functions-deploy/action.yml
@@ -2,7 +2,6 @@ name: Deploy container as Azure Functions
 description: "Deploy container functionApp on Azure"
 
 inputs:
-
   branch:
     required: true
     description: The branch to deploy
@@ -19,40 +18,36 @@ inputs:
     required: true
     description: Azure Tenant ID
     type: string
+  resource_group:
+    required: true
+    description: The resource group of the function to deploy
+    type: string
+  app_name:
+    required: true
+    description: The name of the function to deploy
+    type: string
+  registry_image:
+    required: true
+    description: The name of the image from container registry to be used
+    type: string
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       with:
         ref: ${{ inputs.branch}}
 
     - name: Login via Azure CLI
       uses: azure/login@89d153571fe9a34ed70fcf9f1d95ab8debea7a73
       with:
-        client-id: ${{ inputs.CLIENT_ID }}
-        tenant-id: ${{ inputs.TENANT_ID }}
-        subscription-id: ${{ inputs.SUBSCRIPTION_ID }}
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
 
-    # TODO review login
-#    - name: 'Docker Login'
-#      uses: azure/docker-login@v1
-#      with:
-#        login-server: ghcr.io/${{ github.repository }}
-#        username: ${{ secrets.REGISTRY_USERNAME }}
-#        password: ${{ secrets.REGISTRY_PASSWORD }}
-
-#    - name: 'Compose Customized Docker Image'
-#      shell: bash
-#      run: |
-#        # If your function app project is not located in your repository's root
-#        # Please change the path to your directory for docker build
-#        docker build . -t REGISTRY/NAMESPACE/IMAGE:TAG
-#        docker push REGISTRY/NAMESPACE/IMAGE:TAG
-#
-#    - name: 'Run Azure Functions Container Action'
-#      uses: Azure/functions-container-action@v1
-#      id: fa
-#      with:
-#        app-name: PLEASE_REPLACE_THIS_WITH_YOUR_FUNCTION_APP_NAME
-#        image: REGISTRY/NAMESPACE/IMAGE:TAG
+    - name: 'Run Azure Functions Container Action'
+      uses: Azure/functions-container-action@0aec6197033a72d3ca813f1aebd9391f639c2a8f
+      with:
+        app-name: ${{ inputs.app_name }}
+        image: ${{ inputs.registry_image }}
+        slot-name: production

--- a/azure-functions-deploy/action.yml
+++ b/azure-functions-deploy/action.yml
@@ -18,10 +18,6 @@ inputs:
     required: true
     description: Azure Tenant ID
     type: string
-  resource_group:
-    required: true
-    description: The resource group of the function to deploy
-    type: string
   app_name:
     required: true
     description: The name of the function to deploy

--- a/azure-functions-deploy/action.yml
+++ b/azure-functions-deploy/action.yml
@@ -1,0 +1,58 @@
+name: Deploy container as Azure Functions
+description: "Deploy container functionApp on Azure"
+
+inputs:
+
+  branch:
+    required: true
+    description: The branch to deploy
+    type: string
+  client_id:
+    required: true
+    description: Azure Client ID
+    type: string
+  subscription_id:
+    required: true
+    description: Azure Subscription ID
+    type: string
+  tenant_id:
+    required: true
+    description: Azure Tenant ID
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.branch}}
+
+    - name: Login via Azure CLI
+      uses: azure/login@89d153571fe9a34ed70fcf9f1d95ab8debea7a73
+      with:
+        client-id: ${{ inputs.CLIENT_ID }}
+        tenant-id: ${{ inputs.TENANT_ID }}
+        subscription-id: ${{ inputs.SUBSCRIPTION_ID }}
+
+    # TODO review login
+#    - name: 'Docker Login'
+#      uses: azure/docker-login@v1
+#      with:
+#        login-server: ghcr.io/${{ github.repository }}
+#        username: ${{ secrets.REGISTRY_USERNAME }}
+#        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+#    - name: 'Compose Customized Docker Image'
+#      shell: bash
+#      run: |
+#        # If your function app project is not located in your repository's root
+#        # Please change the path to your directory for docker build
+#        docker build . -t REGISTRY/NAMESPACE/IMAGE:TAG
+#        docker push REGISTRY/NAMESPACE/IMAGE:TAG
+#
+#    - name: 'Run Azure Functions Container Action'
+#      uses: Azure/functions-container-action@v1
+#      id: fa
+#      with:
+#        app-name: PLEASE_REPLACE_THIS_WITH_YOUR_FUNCTION_APP_NAME
+#        image: REGISTRY/NAMESPACE/IMAGE:TAG

--- a/node-semver-setup/README.md
+++ b/node-semver-setup/README.md
@@ -1,0 +1,74 @@
+# Semver setup
+
+This action generates the `semver` and the `environment` as output according to the issue label and 
+the passed action.  
+The semantic version that can be inserted are the following:  
+```
+ - '' -> only in DEV environment on branch != main execute a buildNumber update on the version
+ - promote -> do not execute any update on the version
+ - patch -> execute a patch update on the version, i.e. the third cypher on x.y.Z
+ - new_release -> execute a minor update on the version, i.e. the second cypher on x.Y.z
+ - breaking_change -> execute a major update on the version, i.e. the first cypher on X.y.z
+```
+The following strategy is accepted for the generation of the semantic version with this action:
+```
+IF environment=dev THEN
+    accept [''], [skip], [patch], [new-release] and [breaking-change]
+IF environment=uat THEN
+    accept only [promote] or [patch]
+IF environment=prod THEN
+    accept only [promote] or [patch]
+```
+
+
+## Usage
+
+``` yaml
+on:
+  pull_request:
+    
+  workflow_dispatch:
+    inputs:  
+      environment:
+        required: true
+        type: choice
+        description: Select the Environment
+        options:
+          - dev
+          - uat
+          - prod    
+      semver:
+        required: false
+        type: choice
+        description: Select the version
+        options:
+          - ''
+          - skip
+          - promote
+          - patch
+          - new_release
+          - breaking_change
+  
+  [...]
+  
+  steps:  
+    - name: Semver setup
+      id: semver_setup
+      uses: pagopa/github-actions-template/node-semver-setup@v1
+
+    - run: |
+        echo "${{ steps.get_semver.outputs.semver }}"
+        echo "${{ steps.get_semver.outputs.environment }}"
+```
+
+## Input
+
+No input required.
+
+## Output
+
+| Value       | Description    |
+|-------------|----------------|
+| semver      | Semver Version |
+| environment | Environment    |
+

--- a/node-semver-setup/action.yml
+++ b/node-semver-setup/action.yml
@@ -1,0 +1,73 @@
+name: Semantic version Setup for Node components
+description: "Setting up semantic version according to issue label"
+
+outputs:
+  semver:
+    description: "Semantic Version"
+    value: ${{ steps.get_semver.outputs.semver }}
+  environment:
+    description: "Environment"
+    value: ${{ steps.output.outputs.environment }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Pull request rejected
+      if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged != true
+      run: |
+        echo "❌ PR was closed without a merge"
+        exit 1
+
+    # Set Semver
+    - run: echo "SEMVER=patch" >> $GITHUB_ENV
+
+    - name: Pull request rejected
+      if: ${{ github.event.pull_request.merged && ( github.event.inputs.environment == 'uat' || github.event.inputs.environment == 'prod') && ( contains(github.event.pull_request.labels.*.name, 'breaking-change') || contains(github.event.pull_request.labels.*.name, 'new-release') || contains(github.event.pull_request.labels.*.name, 'ignore-for-release') ) }}
+      run: |
+        echo "❌ UAT and PROD accept only \"patch\" or \"promote\""
+        exit 1
+
+    - if: ${{ github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'ignore-for-release') }}
+      run: echo "SEMVER=skip" >> $GITHUB_ENV
+
+    - if: ${{ (github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'new-release')) }}
+      run: echo "SEMVER=minor" >> $GITHUB_ENV
+
+    - if: ${{ (github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'breaking-change')) }}
+      run: echo "SEMVER=major" >> $GITHUB_ENV
+
+    # force semver if dev, !=main or skip release
+    - if: ${{ inputs.semver == 'new_release' }}
+      run: echo "SEMVER=minor" >> $GITHUB_ENV
+
+    - if: ${{ inputs.semver == 'breaking_change' }}
+      run: echo "SEMVER=major" >> $GITHUB_ENV
+
+    - if: ${{ github.ref_name != 'main' && inputs.semver == '' }}
+      run: echo "SEMVER=buildNumber" >> $GITHUB_ENV
+
+    - if: ${{ inputs.semver == 'promote' || inputs.semver == 'skip' }}
+      run: echo "SEMVER=skip" >> $GITHUB_ENV
+
+    - id: get_semver
+      name: Set Output
+      run: echo "semver=${{env.SEMVER}}" >> $GITHUB_OUTPUT
+
+    # Set Environment
+    - if: ${{ github.event.inputs.environment == null || github.event.inputs.environment == 'dev' }}
+      run: echo "ENVIRONMENT=dev" >> $GITHUB_ENV
+
+    - if: ${{ github.event.inputs.environment == 'uat' }}
+      run: echo "ENVIRONMENT=uat" >> $GITHUB_ENV
+
+    - if: ${{ github.event.inputs.environment == 'prod' }}
+      run: echo "ENVIRONMENT=prod" >> $GITHUB_ENV
+
+    - if: ${{ github.event.inputs.environment == 'all' }}
+      run: echo "ENVIRONMENT=all" >> $GITHUB_ENV
+
+    - id: output
+      name: Set Output
+      run: echo "environment=${{env.ENVIRONMENT}}" >> $GITHUB_OUTPUT
+
+


### PR DESCRIPTION
This PR contains several changes made in order to add new GitHub Actions to be used in deploy context.  
In particular, two new actions were added: one for define the semantic version based on Nodo dei Pagamenti release strategy and one for executing the apply of the Azure Functions by GHA instead of Azure DevOps pipelines.
Also, other two new actions were added in order to, respectively, start and stop the Azure Functions staging slots.

#### List of Changes
- Added new action for the definition of the semantic version
- Added new action for the deploy of the Azure Functions
- Added new action for start staging slots
- Added new action for stop staging slots

#### Motivation and Context
These changes are required in order to fulfill the new strategy of migrating all pipelines on Open Source environments.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.