### PR TITLE
fix: Set coverage_report_path optional parameter

### DIFF
--- a/maven-code-review/action.yml
+++ b/maven-code-review/action.yml
@@ -14,6 +14,11 @@ inputs:
     required: true
     type: string
     description: Key of the project on SonarCloud
+  coverage_report_path:
+    required: false
+    type: string
+    description: Location of jacoco.xml
+    default: './target/site/jacoco/jacoco.xml'
   coverage_exclusions:
     required: false
     type: string
@@ -80,7 +85,7 @@ runs:
     run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       -Dsonar.organization=pagopa
       -Dsonar.projectKey=${{ env.PROJECT_KEY }}
-      -Dsonar.coverage.jacoco.xmlReportPaths=./target/site/jacoco/jacoco.xml
+      -Dsonar.coverage.jacoco.xmlReportPaths=${{inputs.coverage_report_path}}
       -Dsonar.coverage.exclusions=${{inputs.coverage_exclusions}}
       -Dsonar.cpd.exclusions=${{inputs.cpd_exclusions}}
       -Dsonar.host.url=https://sonarcloud.io
@@ -103,7 +108,7 @@ runs:
     run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       -Dsonar.organization=pagopa
       -Dsonar.projectKey=${{ env.PROJECT_KEY }}
-      -Dsonar.coverage.jacoco.xmlReportPaths=./target/site/jacoco/jacoco.xml
+      -Dsonar.coverage.jacoco.xmlReportPaths=${{inputs.coverage_report_path}}
       -Dsonar.coverage.exclusions=${{inputs.coverage_exclusions}}
       -Dsonar.cpd.exclusions=${{inputs.cpd_exclusions}}
       -Dsonar.branch.name=${{ github.head_ref }}


### PR DESCRIPTION
This PR contains the addition of a new parameter on Maven Code Review pipeline. This new parameter, set as optional, permits to change the JaCoCo path used to store the final core-review report.

#### List of Changes
 - Add new parameter for dynamically set JaCoCo coverage filepath

#### Motivation and Context
This change is required because the described path in certain cases can be different from the default value (`./target/site/jacoco/jacoco.xml`)

#### How Has This Been Tested?


#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.