### PR TITLE
fix: resolve deprecation on actions/cache step

### DIFF
--- a/maven-code-review/action.yml
+++ b/maven-code-review/action.yml
@@ -66,14 +66,14 @@ runs:
       maven-version: 3.8.2
 
   - name: Cache Maven packages
-    uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+    uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
     with:
       path: ~/.m2
       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
       restore-keys: ${{ runner.os }}-m2
 
   - name: Cache SonarCloud packages
-    uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+    uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
     with:
       path: ~/.sonar-project.properties/cache
       key: ${{ runner.os }}-sonar-project.properties


### PR DESCRIPTION
This PR contains an edit on Maven Code Review pipeline in order to fix a deprecation on `actions/cache` step. The version of this action will change from v1 to v4.   
The error found is the following:
```
This request has been automatically failed because it uses a deprecated version of `actions/cache: f5ce41475b483ad7581884324a6eca9f48f8dcc7`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

#### List of Changes
 - Upgrading version from v1 to v4

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/155ad0d2-f19d-4deb-82d0-015b5e7af05e)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.